### PR TITLE
🩹 Fixed bug where sorting parameter could not be omitted

### DIFF
--- a/src/Rules/SortParameter.php
+++ b/src/Rules/SortParameter.php
@@ -19,7 +19,7 @@ class SortParameter implements Rule
     public $sortableColumns;
 
     /** @var array $sortingRules */
-    public $sortingRules;
+    public $sortingRules = [];
 
     /**
      * @param array $sortableColumns

--- a/tests/Feature/ModelColumnSortingTest.php
+++ b/tests/Feature/ModelColumnSortingTest.php
@@ -86,4 +86,12 @@ class ModelColumnSortingTest extends TestCase
 
         $response->assertJsonValidationErrors(['sort']);
     }
+
+    /** @test */
+    function it_allows_the_user_to_omit_the_sorting_parameter()
+    {
+        $response = $this->json('GET', '/items');
+
+        $response->assertSuccessful();
+    }
 }


### PR DESCRIPTION
Previously, the sorting parameter could not be omitted, or it would throw an exception. This has been fixed by providing a default value for the sorting rules (empty array)

Also added a test `it_allows_the_user_to_omit_the_sorting_parameter` that makes sure this functionality is tested for from now on.