### PR TITLE
[Update] PHP 7.4+ Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,15 @@ https://example.test/tv-shows?sort=popularity(most-popular)
 
 ## Installation
 
-You can install the package via composer:
+You can download a release and manually include it in your project:
+
+| PHP Version   | Sort Request Version  |
+| ------------- |-----------------------|
+| PHP 7.3       | [Sort Request 1.0](../../releases/tag/1.0.1)             |
+| PHP 7.4       | [Sort Request 2.0](../../releases/tag/2.0)               |
+| PHP 8.0       | [Sort Request 2.0](../../releases/tag/2.0)               |
+
+Alternatively you can install the package via composer:
 
 ```bash
 composer require musa11971/laravel-sort-request
@@ -39,6 +47,9 @@ composer require musa11971/laravel-sort-request
 Add the `SortsViaRequest` trait to your [Laravel form request](https://laravel.com/docs/6.x/validation#form-request-validation).
 
 ```php
+use musa11971\SortRequest\Tests\Support\Requests\FormRequest;
+use musa11971\SortRequest\Traits\SortsViaRequest;
+
 class GetItemsRequest extends FormRequest
 {
     use SortsViaRequest;
@@ -78,7 +89,12 @@ function getSortableColumns(): array
 ```
 
 Next, go to your controller and add the `sortViaRequest` method as follows:
+
 ```php
+use Illuminate\Routing\Controller;
+use musa11971\SortRequest\Tests\Support\Models\Item;
+use musa11971\SortRequest\Tests\Support\Requests\GetItemsRequest;
+
 class ItemController extends Controller
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         }
     ],
     "require": {
-        "php": "^7.3"
+        "php": "^7.4|^8.0"
     },
     "require-dev": {
-        "calebporzio/sushi": "^1.0",
-        "orchestra/testbench": "^4.0",
-        "phpunit/phpunit": "^8.2",
-        "spatie/phpunit-snapshot-assertions": "^3.1",
-        "symfony/var-dumper": "^4.3"
+        "calebporzio/sushi": "^2.0",
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.0",
+        "spatie/phpunit-snapshot-assertions": "^4.2",
+        "symfony/var-dumper": "^5.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/stubs/sorter.stub
+++ b/src/Console/stubs/sorter.stub
@@ -17,7 +17,7 @@ class DummyClass extends Sorter
      *
      * @return Builder
      */
-    public function apply(Request $request, Builder $builder, $direction): Builder
+    public function apply(Request $request, Builder $builder, string $direction): Builder
     {
         // ...
 

--- a/src/EloquentSortingHandler.php
+++ b/src/EloquentSortingHandler.php
@@ -6,18 +6,19 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use musa11971\SortRequest\Exceptions\EloquentSortingException;
 
-class EloquentSortingHandler {
+class EloquentSortingHandler
+{
     /** @var Request $request */
-    private $request;
+    private Request $request;
 
     /** @var Builder $builder */
-    private $builder;
+    private Builder $builder;
 
     /** @var array $rules */
-    private $rules;
+    private array $rules;
 
     /** @var SortableColumnCollection $sortableColumns */
-    private $sortableColumns;
+    private SortableColumnCollection $sortableColumns;
 
     public function __construct($request, $builder)
     {
@@ -35,7 +36,7 @@ class EloquentSortingHandler {
      * @return Builder
      * @throws EloquentSortingException
      */
-    function handle()
+    function handle(): Builder
     {
         // Check whether the request uses the trait before continuing
         $this->checkForTrait();
@@ -58,10 +59,10 @@ class EloquentSortingHandler {
      * Handle the sorting of a column.
      *
      * @param SortableColumn $sortableColumn
-     * @param array $rule
-     * @param Builder $builder
+     * @param array          $rule
+     * @param Builder        $builder
      */
-    private function handleSort($sortableColumn, $rule, &$builder)
+    private function handleSort(SortableColumn $sortableColumn, array $rule, Builder &$builder)
     {
         // Call the sorter's apply method
         $builder = $sortableColumn->sorter->apply(request(), $builder, $rule['direction']);

--- a/src/Exceptions/BadTraitImplementation.php
+++ b/src/Exceptions/BadTraitImplementation.php
@@ -4,7 +4,13 @@ namespace musa11971\SortRequest\Exceptions;
 
 use Exception;
 
-class BadTraitImplementation extends Exception {
+class BadTraitImplementation extends Exception
+{
+    /**
+     * BadTraitImplementation constructor.
+     *
+     * @param $trait
+     */
     public function __construct($trait)
     {
         parent::__construct("Trait: '{$trait}' not implemented properly.");

--- a/src/Exceptions/EloquentSortingException.php
+++ b/src/Exceptions/EloquentSortingException.php
@@ -4,7 +4,13 @@ namespace musa11971\SortRequest\Exceptions;
 
 use Exception;
 
-class EloquentSortingException extends Exception {
+class EloquentSortingException extends Exception
+{
+    /**
+     * EloquentSortingException constructor.
+     *
+     * @param $message
+     */
     public function __construct($message)
     {
         parent::__construct($message);

--- a/src/Rules/SortParameter.php
+++ b/src/Rules/SortParameter.php
@@ -13,18 +13,18 @@ class SortParameter implements Rule
     const SORT_PATTERN = "~(?'column'[a-zA-Z0-9-_]*)\((?'direction'[a-zA-Z0-9-_]*)\)~";
 
     /** @var string $failure */
-    private $failure = 'The :attribute is invalid.';
+    private string $failure = 'The :attribute is invalid.';
 
     /** @var SortableColumnCollection $sortableColumns */
-    public $sortableColumns;
+    public SortableColumnCollection $sortableColumns;
 
     /** @var array $sortingRules */
-    public $sortingRules = [];
+    public array $sortingRules = [];
 
     /**
      * @param array $sortableColumns
      */
-    public function __construct($sortableColumns)
+    public function __construct(array $sortableColumns)
     {
         $this->sortableColumns = $this->transformSortableColumns($sortableColumns);
     }
@@ -32,11 +32,12 @@ class SortParameter implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param  string  $attribute
-     * @param  mixed  $value
+     * @param string $attribute
+     * @param mixed  $value
+     *
      * @return bool
      */
-    public function passes($attribute, $value)
+    public function passes($attribute, $value): bool
     {
         // Go through the value and take out all the rules
         $rules = [];
@@ -78,10 +79,11 @@ class SortParameter implements Rule
     /**
      * Makes the validation rule fail and sets the failure message.
      *
-     * @param $failure
+     * @param string $failure
      * @return bool
      */
-    private function fail($failure) {
+    private function fail(string $failure): bool
+    {
         $this->failure = $failure;
 
         return false;
@@ -92,7 +94,7 @@ class SortParameter implements Rule
      *
      * @return string
      */
-    public function message()
+    public function message(): string
     {
         return $this->failure;
     }
@@ -103,7 +105,7 @@ class SortParameter implements Rule
      * @param $subject
      * @return array|null
      */
-    private function takeNextSortRule(&$subject)
+    private function takeNextSortRule(&$subject): ?array
     {
         if(preg_match(self::SORT_PATTERN, $subject, $match))
         {
@@ -123,9 +125,10 @@ class SortParameter implements Rule
      * Transforms the format used in form requests to a SortableColumnCollection.
      *
      * @param array $columns
+     *
      * @return SortableColumnCollection
      */
-    private function transformSortableColumns($columns)
+    private function transformSortableColumns(array $columns): SortableColumnCollection
     {
         $collection = new SortableColumnCollection();
 

--- a/src/SortableColumn.php
+++ b/src/SortableColumn.php
@@ -6,14 +6,14 @@ use musa11971\SortRequest\Support\Foundation\Contracts\Sorter;
 
 class SortableColumn
 {
-    public $name;
-    public $sorter;
+    public string $name;
+    public Sorter $sorter;
 
     /**
      * @param string $name
      * @param Sorter $sorter
      */
-    public function __construct($name, $sorter)
+    public function __construct(string $name, Sorter $sorter)
     {
         $this->name = $name;
         $this->sorter = $sorter;

--- a/src/SortableColumnCollection.php
+++ b/src/SortableColumnCollection.php
@@ -10,9 +10,10 @@ class SortableColumnCollection extends Collection
      * Checks whether the given column name can be sorted on.
      *
      * @param string $column
+     *
      * @return bool
      */
-    function isValidColumn($column)
+    function isValidColumn(string $column): bool
     {
         $column = $this->find($column);
 
@@ -24,9 +25,10 @@ class SortableColumnCollection extends Collection
      *
      * @param string $column
      * @param string $direction
+     *
      * @return bool
      */
-    function isValidDirectionForColumn($column, $direction)
+    function isValidDirectionForColumn(string $column, string $direction): bool
     {
         $column = $this->find($column);
 
@@ -40,10 +42,10 @@ class SortableColumnCollection extends Collection
     /**
      * Returns the SortableColumn with the given name or null if not found.
      *
-     * @param $column
+     * @param string $column
      * @return SortableColumn|null
      */
-    function find($column)
+    function find(string $column): ?SortableColumn
     {
         foreach($this->items as $item) {
             if($item->name === $column) return $item;

--- a/src/Sorters/DefaultSorter.php
+++ b/src/Sorters/DefaultSorter.php
@@ -13,11 +13,11 @@ class DefaultSorter extends Sorter
      *
      * @param Request $request
      * @param Builder $builder
-     * @param string $direction
+     * @param string  $direction
      *
      * @return Builder
      */
-    public function apply(Request $request, Builder $builder, $direction): Builder
+    public function apply(Request $request, Builder $builder, string $direction): Builder
     {
         $builder->orderBy($this->column, $direction);
 

--- a/src/Support/Foundation/Contracts/Sorter.php
+++ b/src/Support/Foundation/Contracts/Sorter.php
@@ -8,25 +8,25 @@ use Illuminate\Http\Request;
 abstract class Sorter
 {
     /** @var string $column */
-    public $column;
+    public string $column;
 
     /**
      * Applies the sorter to the Eloquent builder.
      *
      * @param Request $request
      * @param Builder $builder
-     * @param string $direction
+     * @param string  $direction
      *
      * @return Builder
      */
-    abstract public function apply(Request $request, Builder $builder, $direction): Builder;
+    abstract public function apply(Request $request, Builder $builder, string $direction): Builder;
 
     /**
      * Returns the directions that can be sorted on.
      *
      * @return array
      */
-    public function getDirections()
+    public function getDirections(): array
     {
         return [];
     }

--- a/src/Traits/SortsViaRequest.php
+++ b/src/Traits/SortsViaRequest.php
@@ -5,6 +5,7 @@ namespace musa11971\SortRequest\Traits;
 use Illuminate\Foundation\Http\FormRequest;
 use musa11971\SortRequest\Exceptions\BadTraitImplementation;
 use musa11971\SortRequest\Rules\SortParameter;
+use musa11971\SortRequest\SortableColumnCollection;
 
 trait SortsViaRequest
 {
@@ -16,7 +17,7 @@ trait SortsViaRequest
     abstract function getSortableColumns(): array;
 
     /** @var SortParameter $sortParameterRule */
-    private $sortParameterRule;
+    private SortParameter $sortParameterRule;
 
     /** @noinspection PhpUnhandledExceptionInspection */
     public function __construct()
@@ -33,7 +34,7 @@ trait SortsViaRequest
      *
      * @return array
      */
-    function validatedSortingRules()
+    function validatedSortingRules(): array
     {
         return $this->sortParameterRule->sortingRules;
     }
@@ -41,9 +42,9 @@ trait SortsViaRequest
     /**
      * Returns the transformed sortable columns.
      *
-     * @return \musa11971\SortRequest\SortableColumnCollection
+     * @return SortableColumnCollection
      */
-    function transformedSortableColumns()
+    function transformedSortableColumns(): SortableColumnCollection
     {
         return $this->sortParameterRule->sortableColumns;
     }
@@ -54,7 +55,7 @@ trait SortsViaRequest
      * @param string $parameterName
      * @return array
      */
-    protected function sortingRules($parameterName = 'sort')
+    protected function sortingRules(string $parameterName = 'sort'): array
     {
         return [
             $parameterName => [$this->sortParameterRule]

--- a/tests/Support/Resources/ItemResource.php
+++ b/tests/Support/Resources/ItemResource.php
@@ -2,7 +2,7 @@
 
 namespace musa11971\SortRequest\Tests\Support\Resources;
 
-use Illuminate\Http\Resources\Json\Resource;
+use Illuminate\Http\Resources\Json\JsonResource as Resource;
 use musa11971\SortRequest\Tests\Support\Models\Item;
 
 class ItemResource extends Resource

--- a/tests/Support/Sorters/ItemWeightSorter.php
+++ b/tests/Support/Sorters/ItemWeightSorter.php
@@ -13,11 +13,11 @@ class ItemWeightSorter extends Sorter
      *
      * @param Request $request
      * @param Builder $builder
-     * @param string $direction
+     * @param string  $direction
      *
      * @return Builder
      */
-    public function apply(Request $request, Builder $builder, $direction): Builder
+    public function apply(Request $request, Builder $builder, string $direction): Builder
     {
         if($direction == 'heavy')
             $builder->orderBy('stackSize', 'desc');


### PR DESCRIPTION
Updated compatibility to PHP 7.4 and PHP 8.0. Also updated minimum version to PHP 7.4.

Bumping release version to 2.0 is advised as this PR breaks compatibility with PHP 7.3.